### PR TITLE
Fix installation path on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ As a result, to avoid further problems, we decided to make FreeCAD LGPL-only, an
 
 The files included here don't need to be downoaded manually. On first use of the dxf importer or exporter, these files will be downloaded and placed in the appropriate directory, and normally the user would never need to worry about this anymore.
 
-If for some reason the automatic download failed, you can always download these files manually and place them into your FreeCAD user folder ($HOME/.FreeCAD on linuxand mac, C:\Users\yourUser\Application Data\FreeCAD on windows before windows7, C:\Users\yoruUser\AppData\Roaming\FreeCAD on windows 7 and later). After that dxf import/export should work normally.
+If for some reason the automatic download failed, you can always download these files manually and place them into your FreeCAD user folder ($HOME/.FreeCAD on linux, $HOME/Library/Preferences/FreeCAD on mac, C:\Users\yourUser\Application Data\FreeCAD on windows before windows7, C:\Users\yoruUser\AppData\Roaming\FreeCAD on windows 7 and later). After that dxf import/export should work normally.
 
 ## DOWNLOAD
 


### PR DESCRIPTION
Python console on 0.16 (6712) on macOS does not list `$HOME/.FreeCAD`
as being in `sys.path` (indented for readability):

```
>>> [path for path in sys.path if path.startswith('/Users')]
[
        '/Users/dusek/Library/Preferences/FreeCAD/Macro',
        '/Users/dusek/Library/Application Support/FreeCAD/Mod',
        '/Users/dusek/Library/Preferences/FreeCAD/'
]
```

I chose the last path from that list since it existed on my system,
and also because it is the shortest one :-).

Placing the `*.py` files into `$HOME/.FreeCAD` previously resulted in error.