### PR TITLE
Changed print, raise and encoding syntax to work with python 3.x

### DIFF
--- a/dxfImportObjects.py
+++ b/dxfImportObjects.py
@@ -150,7 +150,7 @@ class Line:
     def __init__(self, obj):
         """Expects an entity object of type line as input."""
         if not obj.type == 'line':
-            raise TypeError, "Wrong type %s for line object!" %obj.type
+            raise TypeError("Wrong type %s for line object!" %obj.type)
         self.type = obj.type
         self.data = obj.data[:]
         
@@ -210,7 +210,7 @@ class LWpolyline:
     def __init__(self, obj):
         """Expects an entity object of type lwpolyline as input."""
         if not obj.type == 'lwpolyline':
-            raise TypeError, "Wrong type %s for polyline object!" %obj.type
+            raise TypeError("Wrong type %s for polyline object!" %obj.type)
         self.type = obj.type
         self.data = obj.data[:]
         
@@ -314,7 +314,7 @@ class Polyline:
     def __init__(self, obj):
         """Expects an entity object of type polyline as input."""
         if not obj.type == 'polyline':
-            raise TypeError, "Wrong type %s for polyline object!" %obj.type
+            raise TypeError("Wrong type %s for polyline object!" %obj.type)
         self.type = obj.type
         self.data = obj.data[:]
         self.points = []
@@ -391,7 +391,7 @@ class Vertex(object):
         
         if obj is not None:
             if not obj.type == 'vertex':
-                raise TypeError, "Wrong type %s for vertex object!" %obj.type
+                raise TypeError("Wrong type %s for vertex object!" %obj.type)
             self.type = obj.type
             self.data = obj.data[:]
             
@@ -485,7 +485,7 @@ class Text:
     def __init__(self, obj):
         """Expects an entity object of type text as input."""
         if not obj.type == 'text':
-            raise TypeError, "Wrong type %s for text object!" %obj.type
+            raise TypeError("Wrong type %s for text object!" %obj.type)
         self.type = obj.type
         self.data = obj.data[:]
         
@@ -602,7 +602,7 @@ class Mtext:
     def __init__(self, obj):
         """Expects an entity object of type mtext as input."""
         if not obj.type == 'mtext':
-            raise TypeError, "Wrong type %s for mtext object!" %obj.type
+            raise TypeError("Wrong type %s for mtext object!" %obj.type)
         self.type = obj.type
         self.data = obj.data[:]
         
@@ -662,7 +662,7 @@ class Mtext:
             elif item[0] == 3: # There may be any number of extra strings (in order)
                 secondary.append(item[1])
         if not primary:
-            #raise ValueError, "Empty Mtext Object!"
+            #raise ValueError("Empty Mtext Object!")
             string = "Empty Mtext Object!"
         if not secondary:
             string = primary.replace(r'\P', '\n')
@@ -715,7 +715,7 @@ class Circle:
     def __init__(self, obj):
         """Expects an entity object of type circle as input."""
         if not obj.type == 'circle':
-            raise TypeError, "Wrong type %s for circle object!" %obj.type
+            raise TypeError("Wrong type %s for circle object!" %obj.type)
         self.type = obj.type
         self.data = obj.data[:]
         
@@ -788,7 +788,7 @@ class Arc:
     def __init__(self, obj):
         """Expects an entity object of type arc as input."""
         if not obj.type == 'arc':
-            raise TypeError, "Wrong type %s for arc object!" %obj.type
+            raise TypeError("Wrong type %s for arc object!" %obj.type)
         self.type = obj.type
         self.data = obj.data[:]
         
@@ -863,7 +863,7 @@ class BlockRecord:
     def __init__(self, obj):
         """Expects an entity object of type block_record as input."""
         if not obj.type == 'block_record':
-            raise TypeError, "Wrong type %s for block_record object!" %obj.type
+            raise TypeError("Wrong type %s for block_record object!" %obj.type)
         self.type = obj.type
         self.data = obj.data[:]
         
@@ -900,7 +900,7 @@ class Block:
     def __init__(self, obj):
         """Expects an entity object of type block as input."""
         if not obj.type == 'block':
-            raise TypeError, "Wrong type %s for block object!" %obj.type
+            raise TypeError("Wrong type %s for block object!" %obj.type)
         self.type = obj.type
         self.data = obj.data[:]
         
@@ -971,7 +971,7 @@ class Insert:
     def __init__(self, obj):
         """Expects an entity object of type insert as input."""
         if not obj.type == 'insert':
-            raise TypeError, "Wrong type %s for insert object!" %obj.type
+            raise TypeError("Wrong type %s for insert object!" %obj.type)
         self.type = obj.type
         self.data = obj.data[:]
         
@@ -1087,7 +1087,7 @@ class Ellipse:
     def __init__(self, obj):
         """Expects an entity object of type ellipse as input."""
         if not obj.type == 'ellipse':
-            raise TypeError, "Wrong type %s for ellipse object!" %obj.type
+            raise TypeError("Wrong type %s for ellipse object!" %obj.type)
         self.type = obj.type
         self.data = obj.data[:]
         
@@ -1180,7 +1180,7 @@ class Face:
     def __init__(self, obj):
         """Expects an entity object of type 3dfaceplot as input."""
         if not obj.type == '3dface':
-            raise TypeError, "Wrong type %s for 3dface object!" %obj.type
+            raise TypeError("Wrong type %s for 3dface object!" %obj.type)
         self.type = obj.type
         self.data = obj.data[:]
         
@@ -1327,7 +1327,7 @@ def objectify(data):
                 elif item.type == 'seqend':
                     break
                 else:
-                    print "Error: non-vertex found before seqend!"
+                    print("Error: non-vertex found before seqend!")
                     index -= 1
                     break
             objects.append(pline)
@@ -1337,4 +1337,4 @@ def objectify(data):
         index += 1
     return objects    
 if __name__ == "__main__":
-    print "No example yet!"
+    print("No example yet!")

--- a/dxfLibrary.py
+++ b/dxfLibrary.py
@@ -897,7 +897,7 @@ class Drawing(_Collection):
 		for x in data:
 			if not isinstance(x,str):
 				x = x.__str__()
-			file.write(str(x.encode("iso-8859-1"))) # dxf R12 files are expected to be in that encoding
+			file.write(x.encode("iso-8859-1").decode("iso-8859-1")) # dxf R12 files are expected to be in that encoding
 		file.write('  0\nENDSEC\n')
 
 	def saveas(self,fileName,buffer=0):

--- a/dxfReader.py
+++ b/dxfReader.py
@@ -85,11 +85,11 @@ class StateMachine:
 
 	def run(self, cargo=None):
 		if not self.startState:
-			raise InitializationError,\
-				  "must call .set_start() before .run()"
+			raise InitializationError(
+				  "must call .set_start() before .run()")
 		if not self.endStates:
-			raise InitializationError, \
-				  "at least one state must be an end_state"
+			raise InitializationError(
+				  "at least one state must be an end_state")
 		handler = self.startState
 		while 1:
 			(newState, cargo) = handler(cargo)
@@ -98,7 +98,7 @@ class StateMachine:
 				return newState(cargo)
 				#break
 			elif newState not in self.handlers:
-				raise RuntimeError, "Invalid target %s" % newState
+				raise RuntimeError("Invalid target %s" % newState)
 			else:
 				handler = newState
 
@@ -213,7 +213,7 @@ def handleTable(table, infile):
 	while 1:
 		obj = handleObject(infile)
 		if obj.type == 'table':
-			print "Warning: previous table not closed!"
+			print("Warning: previous table not closed!")
 			return table
 		elif obj.type == 'endtab':
 			return table # this means we are done with the table
@@ -234,7 +234,7 @@ def handleBlock(block, infile):
 	while 1:
 		obj = handleObject(infile)
 		if obj.type == 'block':
-			print "Warning: previous block not closed!"
+			print("Warning: previous block not closed!")
 			return block
 		elif obj.type == 'endblk':
 			return block # this means we are done with the table
@@ -283,7 +283,7 @@ def start_section(cargo):
 				while 1: # no way out unless we find an end section or a new section
 					obj = handleObject(infile)
 					if obj == 'section': # shouldn't happen
-						print "Warning: failed to close previous section!"
+						print("Warning: failed to close previous section!")
 						return end_section, (infile, drawing)
 					elif obj == 'endsec': # This section is over, look for the next
 						drawing.data.append(section)
@@ -327,8 +327,8 @@ def error(cargo):
 	infile = cargo[0]
 	err = cargo[1]
 	infile.close()
-	print "There has been an error:"
-	print err
+	print("There has been an error:")
+	print(err)
 	return False
 
 def readDXF(filename):
@@ -381,4 +381,4 @@ if __name__ == "__main__":
 	filename = r".\examples\block-test.dxf"
 	drawing = readDXF(filename)
 	for item in drawing.entities.data:
-		print item
+		print(item)


### PR DESCRIPTION
DXF export doesn't work with FreeCAD 0.17 and python3 without these changes. I didn't test with Python2 so I don't know if it's backward compatible.