### PR TITLE
Fix to import or open DXF files that are somewhat non-standard, i.e. that do not have declared the AutoCAD drawing database version number.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+# Keep Python files with LF only
+*.py text eol=lf
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/dxfReader.py
+++ b/dxfReader.py
@@ -304,8 +304,6 @@ def start_section(infile, drawing, section, acadVersion):
 def end_section(infile, drawing, acadVersion):
 	"""Verifies if we have version info, searches for next section."""
 	#print("Entering end_section state!")
-	#if acadVersion:  # DEBUG (pde)
-	#	print("Got $ACADVER: " + acadVersion)
 	if not acadVersion:
 		acadVersion='AC1021' # a sane pre-initialization for DXF files missing $ACADVER (pde)
 		headerSection = drawing.data[0]
@@ -322,10 +320,8 @@ def end_section(infile, drawing, acadVersion):
 				varValue = convert(item[0], item[1])
 				if varName == '$ACADVER':
 					acadVersion = varValue
-					#print("$ACADVER: " + acadVersion)  # DEBUG (pde)
 				else:
 					DXFcodePage = varValue
-					#print("CP: " + DXFcodePage)  # DEBUG (pde)
 				varName = None
 			if acadVersion and DXFcodePage:
 				break
@@ -333,17 +329,14 @@ def end_section(infile, drawing, acadVersion):
 			return error, (infile, "Unable to identify DXF file version, missing $ACADVER in file!")  # Verbose error message (pde)
 		if acadVersion > 'AC1018':
 			DXFCodePage = 'utf-8'
-			#print("Set default CP UTF-8!")  # DEBUG (pde)
 		elif DXFcodePage:
 			# The codepage name in the DXF file does not use the same convention as the python code page names
 			if DXFcodePage.casefold() == 'ansi_936':  # Case insensitive check (pde)
 				DXFcodePage = 'gbk'
-				#print("Set CP GBK")  # DEBUG (pde)
 			else:
 				match = re.match('(?i)\\Aansi_([0-9]+)\\Z', DXFcodePage)
 				if match:
 					DXFcodePage = 'cp'+match.group(1)
-					#print("Set CP: " + DXFcodePage)  # DEBUG (pde)
 		if DXFcodePage:
 			# Restart with infile changed to the correct encoding. There is no way of changing existing infile
 			# without losing its current position so we must go back to 'start' state.


### PR DESCRIPTION
This should fix the issue [#10554](https://github.com/FreeCAD/FreeCAD/issues/10554) with the non-standard DXF files that are produced by external software like KiCAD and LibreCAD.

At least the DXF files produced by KiCad do not contain the AutoCAD drawing database version number, and therefor the importer fails with the error message `Unable to identify DXF file version`.
I inserted a pre-initialization for the AutoCAD drawing database version number which is then overwritten when there is in fact this info in the DXF file.

Also fixes the case of the codepage info from exported DXF by LibreCAD. 
LibreCAD seems to write the CP in upper case, according to a test file provided by @easyw.